### PR TITLE
[TUX-829] Rename gitlab-chronic -> chronic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+NOTE
+====
+
+This is a fork of https://gitlab.com/gitlab-org/gitlab-chronic, unfortunately Git-Lab renamed the original `chronic` gem as `gitlab-chronic` which avoid us to use it for all the gems relying on the original gem name (`chronic`), for instance: `rufus-scheduler`, `resque-scheduler`, etc.
+
+The main reason of this fork is to rename the gem back to `chronic`.
+
+
 Chronic
 =======
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ def version
 end
 
 def do_test
-  require 'gitlab-chronic'
+  require 'chronic'
   $:.unshift './test'
   Dir.glob('test/test_*.rb').each { |t| require File.basename(t) }
 end
@@ -62,7 +62,7 @@ desc 'Build a gem from the gemspec'
 task :build do
   FileUtils.mkdir_p 'pkg'
   sh 'gem build chronic.gemspec'
-  FileUtils.mv("./gitlab-chronic-#{version}.gem", "pkg")
+  FileUtils.mv("./chronic-#{version}.gem", "pkg")
 end
 
 task :default => :test

--- a/chronic.gemspec
+++ b/chronic.gemspec
@@ -2,14 +2,14 @@ $:.unshift File.expand_path('../lib', __FILE__)
 require 'chronic/version'
 
 Gem::Specification.new do |s|
-  s.name = 'gitlab-chronic'
+  s.name = 'chronic'
   s.version = Chronic::VERSION
   s.rubyforge_project = 'chronic'
   s.summary     = 'Natural language date/time parsing.'
   s.description = 'Chronic is a natural language date/time parser written in pure Ruby.'
   s.authors  = ['Tom Preston-Werner', 'Lee Jarvis']
   s.email    = ['tom@mojombo.com', 'ljjarvis@gmail.com']
-  s.homepage = 'https://gitlab.com/gitlab-org/gitlab-chronic'
+  s.homepage = 'https://github.com/StreetEasy/chronic'
   s.license = 'MIT'
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = %w[README.md HISTORY.md LICENSE]


### PR DESCRIPTION
The original [chronic](https://github.com/mojombo/chronic) ruby gem has a bug related with [Daylight Saving not handled properly](https://github.com/mojombo/chronic/issues/147), there is a [Pull Request](https://github.com/mojombo/chronic/pull/396) that fixes the bug, however because the gem is not longer maintained it has been merged yet. Gitlab forked the original Chronic gem and renamed it as [gitlab-chronic](https://gitlab.com/gitlab-org/gitlab-chronic), unfortunately because of the new name, libraries depending - like `rufus-scheduler`, `resque-scheduler` - on `chronic` can’t use the `gitlab-chronic` gem. 

This Pull Request renames the gem back to `chronic`.